### PR TITLE
build:  Add api proxy and update compose

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,41 @@
+localhost:80 {
+    encode
+
+    handle /api/* {
+        header {
+            access-control-allow-origin      "http://localhost"
+            access-control-allow-credentials true
+            access-control-allow-headers     {http.request.header.access-control-request-headers}
+            access-control-allow-methods     "get, post, put, options"
+        }
+        reverse_proxy https://play.picoctf.org {
+            header_up host            play.picoctf.org
+            header_up origin          https://play.picoctf.org
+            header_up referer         https://play.picoctf.org
+        }
+    }
+
+    handle /static/* {
+        header {
+            access-control-allow-origin      "http://localhost"
+            access-control-allow-credentials true
+            access-control-allow-headers     {http.request.header.access-control-request-headers}
+            access-control-allow-methods     "get, options"
+        }
+        reverse_proxy https://play.picoctf.org {
+            header_up host            play.picoctf.org
+            header_up origin          https://play.picoctf.org
+            header_up referer         https://play.picoctf.org
+        }
+    }
+
+    reverse_proxy http://frontend:5173
+
+    @preflight {
+        method OPTIONS
+        path /api/*
+    }
+    handle @preflight {
+        respond "OK" 204
+    }
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,14 +16,33 @@ services:
       dockerfile: frontend.Dockerfile
       context: ./frontend/react_app
     ports:
-      - 6006:6006
-      - 5173:5173
-    # volumes:
-    #   - ./frontend/react_app:/app
-    #   - exclude:app:/node_modules/
+      - 6006:6006   # Hit storybook directly, no need for API proxy
+    expose:
+      - 5173:5173   # Accessed via http://localhost to enable /api proxying to production API
+    volumes:
+      - ./frontend/react_app:/app                # Bind mount for live reloading
+      - frontend_node_modules:/app/node_modules  # Named volume for performance
+    networks:
+      - app-network
+
+  caddy:
+    image: caddy:latest
+    container_name: caddy-server
+    ports:
+      - "80:80"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+    depends_on:
+      - frontend
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge
 
 volumes:
-  exclude:
+  frontend_node_modules:
 
 # The commented out section below is an example of how to define a PostgreSQL
 # database that your application can use. `depends_on` tells Docker Compose to

--- a/frontend/react_app/frontend.Dockerfile
+++ b/frontend/react_app/frontend.Dockerfile
@@ -20,13 +20,6 @@ COPY /package*.json /app
 # into this layer.
 RUN npm install --include=dev
 
-# Copy the rest of the source files into the image.
-COPY . /app
-
-# Expose the port that the application listens on.
-EXPOSE 6006
-EXPOSE 5173
-
 # Run the application.
 # CMD ["npm", "run", "dev"]
 CMD npm run dev -- --host & npm run storybook


### PR DESCRIPTION
- Add caddy for rev proxy to play.picoctf.org/api
- Network caddy to now expose port for vite
- Add named volume for node_modules
- Direct bind app folder for HMR

----

You may need to destroy any existing container/image/volumes and recreate them. Access the app at http://localhost  (no port)

Accessing storybook is unchanged since it doesn't have any API interaction: http://localhost:6006

Test API proxying to production (equivalent to accessing https://play.picoctf.org/api/settings/):

```
$ curl -s http://localhost/api/settings/ | json_pp
{
   "DEFAULT_PAGE_SIZE" : 10,
   "GOOGLE_TAG_ID" : "UA-93258343-6",
   "GYM_SPONSORS" : [],
   "PLATFORM_NAME" : "picoCTF",
   "RECAPTCHA_ENABLED" : true,
   "RECAPTCHA_SITE_KEY" : "6LeR780ZAAAAAEeKBVVmMwEdCkb0a29rp3ulV00I",
   "REQUIRE_ACCOUNT_DEMOGRAPHICS" : true,
   "VERIFICATION_GRACE_DAYS" : 7,
   "WEBSHELL_URL" : "https://webshell.picoctf.org"
}
```

Note: Registration api may not work, because that depends on recaptcha validation that is kinda hard coded into the real site